### PR TITLE
Initialize existing networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ honoring docker network opts yet.
 
 In the repo directory, use the binary named `macvlan-docker-plugin-0.3-Linux-x86_64`. Feel free to rename it :)
 
+**Note**: There is no need to add any paramters to the plugin daemon (other then `-d` debug for example). All options are passed via native Docker commands.
+
 ```
 $ git clone https://github.com/gopher-net/macvlan-docker-plugin.git
 $ cd macvlan-docker-plugin/binaries
-$ ./macvlan-docker-plugin-0.3-Linux-x86_64 -d --host-interface=eth1 --mode=bridge
+$ ./macvlan-docker-plugin-0.3-Linux-x86_64 -d
 
 # -d is debug
 # --host-interface is the master interface, eth0, eth1 etc. The docker network create needs to correspond to that subnet for bridge mode

--- a/plugin/macvlan/utils.go
+++ b/plugin/macvlan/utils.go
@@ -37,6 +37,7 @@ func getIfaceAddr(name string) (*net.IPNet, error) {
 	return addrs[0].IPNet, nil
 }
 
+// setVlanMode set the macvlan mode, currently only bridge is supported since others are rarely deployed
 func setVlanMode(mode string) (netlink.MacvlanMode, error) {
 	switch mode {
 	case "private":
@@ -75,4 +76,13 @@ func validateHostIface(ifaceStr string) bool {
 		return false
 	}
 	return true
+}
+
+// parseIPNet returns a net.IP from a network cidr in string representation
+func parseIPNet(s string) (*net.IPNet, error) {
+	ip, ipNet, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil, err
+	}
+	return &net.IPNet{IP: ip, Mask: ipNet.Mask}, nil
 }


### PR DESCRIPTION
- This will query existing endpoint networks at runtime in order
  to survive a plugin restart.
